### PR TITLE
Fix : " 로그인 수정 "

### DIFF
--- a/routes/users.router.js
+++ b/routes/users.router.js
@@ -1,10 +1,13 @@
 import express from 'express';
 import { prisma } from '../utils/prisma/prismaClient.js'
-import { CreateAccessToken } from '../utils/token/tokenCreate.js'
-import { CreateRefreshToken } from '../utils/token/tokenCreate.js'
+import { CreateAccessToken, CreateRefreshToken, ValidateToken } from '../utils/token/tokenCreate.js'
+import { MakeTime, TimeDifference } from '../utils/time/time.js';
 import bcrypt from 'bcrypt';
+import loginAuthMiddleware from '../middlewares/loginAuth.middleware.js';
+import dotenv from 'dotenv';
 
 const usersRouter = express.Router();
+dotenv.config();
 
 // 회원가입
 usersRouter.post('/Sign-Up', async (req, res, next) => {
@@ -25,7 +28,7 @@ usersRouter.post('/Sign-Up', async (req, res, next) => {
 
     if (password !== confirmPassword) {
         return res.status(404).json({ message: `비밀번호와 비밀번호 확인이 일치하지 않습니다.` });
-    }    
+    }
 
     const hashedPassword = await bcrypt.hash(password, 10);
 
@@ -37,19 +40,19 @@ usersRouter.post('/Sign-Up', async (req, res, next) => {
             id: id,
             password: hashedPassword
         }
-    });   
+    });
 
     // 랭킹 생성해서 Ranking table에 저장
     const rank = await prisma.ranking.create({
-        data:{
-            userId : user.userId            
+        data: {
+            userId: user.userId
         }
     });
 
     // 스쿼드 생성해서 Squad table에 저장
     const squad = await prisma.squad.create({
-        data:{
-            userId : user.userId
+        data: {
+            userId: user.userId
         }
     });
 
@@ -58,24 +61,118 @@ usersRouter.post('/Sign-Up', async (req, res, next) => {
         .json({ message: `${id}로 회원가입이 완료되었습니다.` });
 });
 
+//------------------------------------------------------
+// 처음 로그인
+//------------------------------------------------------
+async function FirstLogin(id, refreshTokenDBData, res) {
+    if (refreshTokenDBData === null) {
+        // RefreshToken이 Table에 없음
+        // 처음 로그인 대상으로 해석
+        // JWT로 AccessToken 생성
+        const s2cAccessToken = CreateAccessToken(id);
+        // JWT로 RefreshToken 생성
+        const s2cRefreshToken = CreateRefreshToken(id);
+
+        // 응답 헤더에 accessToken 기록
+        res.header("authorization", s2cAccessToken);
+
+        const nowTime = MakeTime(false);
+        const expiredAtTokenTime = MakeTime(false, parseInt(process.env.REFRESH_TOKEN_EXPIRE_TIME_DB));
+
+        // RefreshToken DB에 저장
+        const refreshToken = await prisma.refreshTokens.create({
+            data: {
+                id: id,
+                token: s2cRefreshToken,
+                createdAt: nowTime,
+                expiredAt: expiredAtTokenTime
+            }
+        });
+
+        return res.status(200).json({ message: `${id}로 로그인에 성공했습니다.` });
+    }
+    else {
+        // RefreshToken이 Table에 있음
+        // 1. 이전에 처음 로그인 대상으로 accessToken을 발급받고, RefreshToken을 발급받았지만
+        //    accessToken을 헤더에 기록하지 않은 경우
+        // 2. 불량 유저 ( 근거가 애매함 ) 남의 아이디를 도용해 접근하면 확실히 불량유저
+
+        // return res.status(200).json({message : `로그인 했던 유저입니다. AccessToken을 헤더에 입력해서 다시 로그인하세요.`});
+        const s2cAccessToken = CreateAccessToken(id);
+        res.header("authorization", s2cAccessToken);
+
+        return res.status(200).json({ message: `${id}로 로그인에 성공했습니다.` });
+    }
+}
+
+//---------------------------------------------------------------
+// AccessToken 만료
+//---------------------------------------------------------------
+async function AccessTokenExpired(id, refreshTokenDBData, res) {
+    if (refreshTokenDBData !== null) {
+        // AccessToken을 가지고 있고, AccessToken이 만료됨
+        // refreshToken을 DB에 가지고 있음
+
+        // AccessToken을 재발급
+        // RefreshToken이 만료되었는지 확인
+        const refreshTokenCheck = ValidateToken(refreshTokenDBData, process.env.REFRESH_TOKEN_SECRET_KEY);
+        if (!refreshTokenCheck) {
+            // RefreshDB createdAt, expiredAt 컬럼 사용 용도 : 
+            // JWT 없이 Refresh Token의 Expire 시간을 제어할 수 있는 용도로 사용
+            // 예) JWT로 3시간 후 만료로 발급했으나 모종의 이유로 1시간 후 만료로 바꿔야하는 경우,
+            //     JWT는 수정을 할 수 없기 때문에 DB에 있는 시간값으로 판정한다.
+
+            // 현재 시간과 db에 저장되어 있는 시간 차를 구함
+            const dbTimeDifferenceSecond = TimeDifference(refreshTokenDBData.expiredAt, "second");
+
+            // 상수값으로 설정해둔 Refresh Token 만료 시간을 지나면 
+            if (dbTimeDifferenceSecond >= parseInt(process.env.REFRESH_TOKEN_EXPIRE_DB_CHECK_TIME)) {
+                // RefreshToken을 재발급
+                const s2cRefreshToken = CreateRefreshToken(id);
+
+                // 현재 시간을 구함
+                const nowTime = MakeTime(false);
+                // Refresh Token 만료 시간을 구함
+                const expiredTime = MakeTime(false, parseInt(process.env.REFRESH_TOKEN_EXPIRE_TIME_DB));
+
+                // Refresh Token을 업데이트
+                await prisma.refreshTokens.update({
+                    where: { id: id },
+                    data: {
+                        token: s2cRefreshToken,
+                        createdAt: nowTime,
+                        expiredAt: expiredTime
+                    }
+                });
+            }
+        }
+
+        const s2cAccessToken = CreateAccessToken(id);
+        res.header("authorization", s2cAccessToken);
+
+        return res.status(200).json({ message: `AccessToken이 재발급 되었습니다. ${id}로 로그인에 성공했습니다. ` });
+    }
+    else {
+        // AccessToken을 가지고 있고, AccessToken이 만료됨
+        // refreshToken을 DB에 가지고 있지 않음
+        // 불량 유저로 판정 ( 서버에 문제가 생겨 refreshToken을 기록 못할경우가 있어서 불량 유저로 판정하기엔 무리)      
+        // return res.status(404).json({ message: `비정상 로그인 시도` });
+
+        return res.status(404).json({ message: `refreshToken DB Empty` });
+    }
+}
+
+function DifferentAccessToken(refreshTokenDBData, res) {
+    if (refreshTokenDBData == null) {
+        return res.status(404).json({ message: `처음 로그인하는 아이디입니다. 헤더에 있는 authorization 지우고 로그인하세요.` })
+    }
+    else {
+        return res.status(404).json({ message: `다른 ID의 AccessToken으로 로그인을 시도했습니다. 올바른 AccessToken을 입력하세요.` });
+    }
+}
+
 // 로그인
-// 1. 클라가 서버에 로그인 요청
-// 1-1 아이디가 UserDB에 있는지 확인
-// 1-2 비밀번호가 맞는지 확인
-// 2. 인증 절차 수행, 인증이 유효하면 Access Token과 Refresh Token을 클라에게 발급, Refresh Token은 DB에 저장
-
-// 1. 클라는 요청 시 요청 헤더의 Authoriztion에 발급 받은 Access Token을 "Bearer JWT 토큰" 형식으로 담아 보내준다.
-// 2. 서버는 전달 받은 JWT를 검증하고 응답한다.
-
-// 1. 만약 Access Token이 만료됐으면 서버는 DB에 저장되어 있는 Refresh Token을 이용해 새로운 Access token을 발급 받는다.
-// 1-1 이때 재발급 요청은 별도의 router에서 진행한다. ( 예: /token/refresh)
-// 2. 서버는 요청을 보낸 클라의 Refresh Token과 DB에 저장되어 있는 Refresh Token을 비교해 유효한 것으로 판단되면 
-//    새로운 Access Token을 발급하고 클라에게 전달한다.
-// 3. 클라가 로그아웃을 한다면 DB에서 Refresh Token을 삭제해 사용할 수 없도록 하고, 
-//    다시 로그인하면 새로 생성된 Refresh Token을 DB에 저장한다.
-
-// 로그인
-usersRouter.post('/Sign-In', async (req, res, next) => {
+usersRouter.post('/Sign-In', loginAuthMiddleware, async (req, res, next) => {
     // 아이디, 비밀번호 가져오기
     const { id, password } = req.body;
 
@@ -89,24 +186,39 @@ usersRouter.post('/Sign-In', async (req, res, next) => {
     // 아이디 검사
     if (!user) {
         return res.status(404).json({ message: `${id}은 존재하지 않는 아이디 입니다.` });
-    }    
-    
+    }
+
     // 비밀번호 검사
     if (!(await bcrypt.compare(password, user.password))) {
         return res.status(404).json({ message: `비밀번호가 일치하지 않습니다.` });
     }
 
-    const auth = req.headers.authorization;
+    // RefreshTokens 테이블에 RefreshToken이 있는지 확인
+    const refreshTokenExist = await prisma.refreshTokens.findFirst({
+        where: {
+            id: id
+        }
+    });
 
-    // JWT로 AccessToken 생성
-    const s2cAccessToken = CreateAccessToken(id);
-    // JWT로 RefreshToken 생성
-    const s2cRefreshToken = CreateRefreshToken(id);     
-
-    // 응답 헤더에 accessToken 기록
-    res.header("authorization", s2cAccessToken);
-
-    return res.status(200).json({ message: `${id}로 로그인에 성공했습니다.`});
+    switch (req.authLoginState) {
+        case process.env.LOGIN_AUTH_FAIL_AUTHORIZATION_NOT_FOUND:
+            // AccessToken이 없음
+            FirstLogin(id, refreshTokenExist, res);
+            break;
+        case process.env.LOGIN_AUTH_FAIL_TOKEN_TYPE_NOT_MATCH:
+            // AccessToken을 가지고 있지만 토큰 타입이 일치하지 않음
+            return res.status(404).json({ message: '토큰 타입이 일치하지 않습니다.' });
+        case process.env.LOGIN_AUTH_FAIL_TOKEN_EXPIRED:
+            // AccessToken이 만료됨
+            AccessTokenExpired(id, refreshTokenExist, res);
+            break;
+        case process.env.LOGIN_AUTH_FAIL_DIFFERENT_ACCESS_TOKEN:
+            DifferentAccessToken(refreshTokenExist, res);
+            break;
+        case process.env.LOGIN_AUTH_SUCCESS:
+            // 로그인 성공
+            return res.status(200).json({ message: `${id}로 로그인에 성공했습니다.` });
+    }
 })
 
 export default usersRouter;


### PR DESCRIPTION
users.router.js 수정
 - MakeTime, TimeDifference 함수 가져오기 추가
 - ValidateToken 함수 가져오기 추가
 - loginAuthMiddleware 가져오기 추가
 - dotenv 가져오기 추가

 - FirstLogin(id, refreshTokenDBData, res ) 함수 추가
  - 처음 로그인한 대상을 판단해서 AccessToken과 RefreshToken을 생성해 주고 RefreshToken을 DB에 저장

 - AccessTokenExpired(id, refreshToekenDBData, res ) 함수 추가
  - 로그인 시도하는 대상의 AccessTokem이 만료되었을 경우 재발급 해주는 함수

 - DifferentAccessToken(refreshTokenDBData, res) 함수 추가
  - 다른 AcessToken을 가지고 올 경우 적절한 에러 메세지 클라에게 전달

 - usersRouter.post('Sigin-In') 수정 ( 로그인 수정 )
  - loginAuth.middleware에서 처리한 req.authLoginState 값에 따라 다르게 로직 처리
   - LOGIN_AUTH_FAIL_AUTHORIZATION_NOT_FOUN ( AccessToken이 없을 경우 )
   - LOGIN_AUTH_FAIL_TOKEN_TYPE_NOT_MATCH ( AccessToken을 가지고 있으나 토큰 타입이 일치하지 않을 경우 )
   - LOGIN_AUTH_FAIL_TOKEN_EXPIRED ( AccessToken이 만료된 경우 )
   - LOGIN_AUTH_FAIL_DIFFERENT_ACCESS_TOKEN ( 다른 유저의 AccessToken으로 가지고 올 경우 )
   - LOGIN_AUTH_SUCCESS ( 로그인 성공 )